### PR TITLE
fix: Search for compose.ya?ml

### DIFF
--- a/src/util/files-finder.ts
+++ b/src/util/files-finder.ts
@@ -20,8 +20,8 @@ export function findFilesForLinting(paths: string[], recursive: boolean, exclude
     const exclude = Array.from(excludeSet);
     logger.debug('UTIL', `Paths to exclude: ${exclude.toString()}`);
 
-    // Regular expression to match docker-compose*.yml and docker-compose*.yaml files
-    const dockerComposePattern = /^docker-compose.*\.(yml|yaml)$/;
+    // Regular expression to match [compose*.yml, compose*.yaml, docker-compose*.yml, docker-compose*.yaml] files
+    const dockerComposePattern = /^(docker-)?compose.*\.ya?ml$/;
 
     paths.forEach((fileOrDir) => {
         if (!fs.existsSync(fileOrDir)) {


### PR DESCRIPTION
According to the compose documentation `compose.yaml` and `compose.yml` are preferred file names for docker compose.

This small fix changes the regex pattern to account for file names that start with `compose` instead of `docker-compose`.

docs: https://docs.docker.com/compose/intro/compose-application-model/#the-compose-file