### PR TITLE
feat: require port bindings to include inferface ip

### DIFF
--- a/src/rules/no-implicit-listen-everywhere-ports-rule.ts
+++ b/src/rules/no-implicit-listen-everywhere-ports-rule.ts
@@ -1,0 +1,80 @@
+import { parseDocument, isMap, isSeq, isScalar } from 'yaml';
+import type {
+    LintContext,
+    LintMessage,
+    LintMessageType,
+    LintRule,
+    LintRuleCategory,
+    LintRuleSeverity,
+    RuleMeta,
+} from '../linter/linter.types.js';
+import { findLineNumberForService } from '../util/line-finder.js';
+import { extractPublishedPortValue, extractPublishedPortInferfaceValue } from '../util/service-ports-parser.js';
+
+export default class NoDuplicateExportedPortsRule implements LintRule {
+    public name = 'no-duplicate-exported-ports';
+
+    public type: LintMessageType = 'error';
+
+    public category: LintRuleCategory = 'security';
+
+    public severity: LintRuleSeverity = 'critical';
+
+    public meta: RuleMeta = {
+        description:
+            'Ensure that exported ports in Docker Compose are bound to specific Interfaces to prevent accidential exposure of containers.',
+        url: 'https://github.com/zavoloklom/docker-compose-linter/blob/main/docs/rules/no-duplicate-exported-ports-rule.md',
+    };
+
+    public fixable = false;
+
+    // eslint-disable-next-line class-methods-use-this
+    public getMessage({ serviceName, publishedPort }: { serviceName: string; publishedPort: string }): string {
+        return `Service "${serviceName}" is exporting port "${publishedPort}" without specifing the interface to listen on.`;
+    }
+
+    public check(context: LintContext): LintMessage[] {
+        const errors: LintMessage[] = [];
+        const doc = parseDocument(context.sourceCode);
+        const services = doc.get('services');
+
+        if (!isMap(services)) return [];
+
+        services.items.forEach((serviceItem) => {
+            if (!isScalar(serviceItem.key)) return;
+
+            const serviceName = String(serviceItem.key.value);
+            const service = serviceItem.value;
+
+            if (!isMap(service) || !service.has('ports')) return;
+
+            const ports = service.get('ports');
+            if (!isSeq(ports)) return;
+
+            ports.items.forEach((portItem) => {
+                const publishedInterface = extractPublishedPortInferfaceValue(portItem);
+                const publishedPort = extractPublishedPortValue(portItem);
+
+                if (publishedInterface === '') {
+                    const line = findLineNumberForService(doc, context.sourceCode, serviceName, 'ports');
+                    errors.push({
+                        rule: this.name,
+                        type: this.type,
+                        category: this.category,
+                        severity: this.severity,
+                        message:
+                            this.getMessage({
+                                serviceName,
+                                publishedPort,
+                            }) + String(ports),
+                        line,
+                        column: 1,
+                        meta: this.meta,
+                        fixable: this.fixable,
+                    });
+                }
+            });
+        });
+        return errors;
+    }
+}

--- a/src/util/service-ports-parser.ts
+++ b/src/util/service-ports-parser.ts
@@ -5,8 +5,13 @@ function extractPublishedPortValue(yamlNode: unknown): string {
     if (isScalar(yamlNode)) {
         const value = String(yamlNode.value);
 
-        // Check for host before ports
-        const parts = value.split(':');
+        // Split on single colon
+        const parts = value.split(/:(?![^[]*\])/);
+
+        if (parts[0].startsWith('[') && parts[0].endsWith(']')) {
+            parts[0] = parts[0].slice(1, -1);
+        }
+
         if (net.isIP(parts[0])) {
             return String(parts[1]);
         }
@@ -16,6 +21,31 @@ function extractPublishedPortValue(yamlNode: unknown): string {
 
     if (isMap(yamlNode)) {
         return String(yamlNode.get('published')) || '';
+    }
+
+    return '';
+}
+
+function extractPublishedPortInferfaceValue(yamlNode: unknown): string {
+    if (isScalar(yamlNode)) {
+        const value = String(yamlNode.value);
+
+        // Split on single colon
+        const parts = value.split(/:(?![^[]*\])/);
+
+        if (parts[0].startsWith('[') && parts[0].endsWith(']')) {
+            parts[0] = parts[0].slice(1, -1);
+        }
+
+        if (net.isIP(parts[0])) {
+            return String(parts[0]);
+        }
+
+        return '';
+    }
+
+    if (isMap(yamlNode)) {
+        return String(yamlNode.get('host_ip')) || '';
     }
 
     return '';
@@ -45,4 +75,4 @@ function parsePortsRange(port: string): string[] {
     return ports;
 }
 
-export { extractPublishedPortValue, parsePortsRange };
+export { extractPublishedPortValue, extractPublishedPortInferfaceValue, parsePortsRange };

--- a/tests/rules/no-implicit-listen-everywhere-ports-rule.spec.ts
+++ b/tests/rules/no-implicit-listen-everywhere-ports-rule.spec.ts
@@ -1,0 +1,66 @@
+import test from 'ava';
+import { parseDocument } from 'yaml';
+import NoImplicitListenEverywherePortsRule from '../../src/rules/no-implicit-listen-everywhere-ports-rule.js';
+import type { LintContext } from '../../src/linter/linter.types.js';
+
+// YAML with multiple duplicate exported ports
+const yamlWithImplicitListenEverywherePorts = `
+services:
+  a-service:
+    image: nginx
+    ports:
+      - 8080:80
+  b-service:
+    image: nginx
+    ports:
+      - 8080
+`;
+
+// YAML with unique exported ports using different syntax
+const yamlWithExplicitListenIPPorts = `
+services:
+  a-service:
+    image: nginx
+    ports:
+      - 0.0.0.0:8080:8080
+  b-service:
+    image: nginx
+    ports:
+      - 127.0.0.1:8081:8081
+      - '[::1]:8082:8082'
+`;
+
+const filePath = '/docker-compose.yml';
+
+test('NoImplicitListenEverywherePortsRule: should return multiple errors when duplicate exported ports are found', (t) => {
+    const rule = new NoImplicitListenEverywherePortsRule();
+    const context: LintContext = {
+        path: filePath,
+        content: parseDocument(yamlWithImplicitListenEverywherePorts).toJS() as Record<string, unknown>,
+        sourceCode: yamlWithImplicitListenEverywherePorts,
+    };
+
+    const errors = rule.check(context);
+    t.is(errors.length, 2, 'There should be two errors when ports without host_ip are found.');
+
+    const expectedMessages = [
+        'Service "a-service" is exporting port "8080" without specifing the interface to listen on.',
+        'Service "b-service" is exporting port "8080" without specifing the interface to listen on.',
+    ];
+
+    errors.forEach((error, index) => {
+        t.true(error.message.includes(expectedMessages[index]));
+    });
+});
+
+test('NoImplicitListenEverywherePortsRule: should not return errors when exported ports have host_ip configured', (t) => {
+    const rule = new NoImplicitListenEverywherePortsRule();
+    const context: LintContext = {
+        path: filePath,
+        content: parseDocument(yamlWithExplicitListenIPPorts).toJS() as Record<string, unknown>,
+        sourceCode: yamlWithExplicitListenIPPorts,
+    };
+
+    const errors = rule.check(context);
+    t.is(errors.length, 0, errors.map((error) => error.message).join(', '));
+});

--- a/tests/util/service-ports-parser.spec.ts
+++ b/tests/util/service-ports-parser.spec.ts
@@ -1,6 +1,10 @@
 import test from 'ava';
 import { Scalar, YAMLMap } from 'yaml';
-import { extractPublishedPortValue, parsePortsRange } from '../../src/util/service-ports-parser.js';
+import {
+    extractPublishedPortValue,
+    extractPublishedPortInferfaceValue,
+    parsePortsRange,
+} from '../../src/util/service-ports-parser.js';
 
 test('extractPublishedPortValue should return port from scalar value with no IP', (t) => {
     const scalarNode = new Scalar('8080:9000');
@@ -10,6 +14,12 @@ test('extractPublishedPortValue should return port from scalar value with no IP'
 
 test('extractPublishedPortValue should return correct port from scalar value with IP', (t) => {
     const scalarNode = new Scalar('127.0.0.1:3000');
+    const result = extractPublishedPortValue(scalarNode);
+    t.is(result, '3000');
+});
+
+test('extractPublishedPortValue should return correct port from scalar value with IPv6', (t) => {
+    const scalarNode = new Scalar('[::1]:3000');
     const result = extractPublishedPortValue(scalarNode);
     t.is(result, '3000');
 });
@@ -24,6 +34,42 @@ test('extractPublishedPortValue should return published port from map node', (t)
 test('extractPublishedPortValue should return empty string for unknown node type', (t) => {
     const result = extractPublishedPortValue({});
     t.is(result, '');
+});
+
+test('extractPublishedPortInferfaceValue should return listen ip string for scalar without IP', (t) => {
+    const scalarNode = new Scalar('8080:8080');
+    const result = extractPublishedPortInferfaceValue(scalarNode);
+    t.is(result, '');
+});
+
+test('extractPublishedPortInferfaceValue should return listen ip string for scalar without IP and automapped port', (t) => {
+    const scalarNode = new Scalar('8080');
+    const result = extractPublishedPortInferfaceValue(scalarNode);
+    t.is(result, '');
+});
+
+test('extractPublishedPortInferfaceValue should return listen ip string for scalar on 127.0.0.1 with automapped port', (t) => {
+    const scalarNode = new Scalar('127.0.0.1:8080');
+    const result = extractPublishedPortInferfaceValue(scalarNode);
+    t.is(result, '127.0.0.1');
+});
+
+test('extractPublishedPortInferfaceValue should return listen ip string for scalar on 0.0.0.0 with automapped port', (t) => {
+    const scalarNode = new Scalar('0.0.0.0:8080');
+    const result = extractPublishedPortInferfaceValue(scalarNode);
+    t.is(result, '0.0.0.0');
+});
+
+test('extractPublishedPortInferfaceValue should return listen ip string for scalar on ::1 with automapped port', (t) => {
+    const scalarNode = new Scalar('[::1]:8080');
+    const result = extractPublishedPortInferfaceValue(scalarNode);
+    t.is(result, '::1');
+});
+
+test('extractPublishedPortInferfaceValue should return listen ip string for scalar on ::1 without automated port', (t) => {
+    const scalarNode = new Scalar('[::1]:8080:8080');
+    const result = extractPublishedPortInferfaceValue(scalarNode);
+    t.is(result, '::1');
 });
 
 test('parsePortsRange should return array of ports for a range', (t) => {


### PR DESCRIPTION
Intention: binding to a port often unintentionally exposes services to the local network. Often seen when developers start databases in a Container and expose it via port-exposing to the local application. Sadly this is done often without limiting the port binding to localhost. Gets even worse when no password for the database is set up. 

So this will warn when no Interfaces/HostIP is specified. 