### PR TITLE
Allow `$schema` in JSON configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,18 @@ Here is an example of a configuration file using JSON format:
 - **debug**: Enables debug mode with additional output if set to `true`.
 - **exclude**: Specifies files or directories to exclude from linting.
 
+To enable editor autocompletion in a JSON configuration file, add a `$schema` property. If you have installed `dclint`:
+
+```json
+"$schema": "./node_modules/dclint/schemas/linter-config.schema.json",
+```
+
+Otherwise:
+
+```json
+"$schema": "https://raw.githubusercontent.com/zavoloklom/docker-compose-linter/refs/heads/main/schemas/linter-config.schema.json",
+```
+
 ### Configure Rules
 
 In addition to enabling or disabling rules, some rules may support custom parameters to tailor them to your specific

--- a/schemas/linter-config.schema.json
+++ b/schemas/linter-config.schema.json
@@ -2,6 +2,9 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "rules": {
       "type": "object",
       "propertyNames": {


### PR DESCRIPTION
## Description

The `$schema` property can be used by editors to provide inline
documentation and validation in JSON files (see [VS Code's
documentation](https://code.visualstudio.com/Docs/languages/json#_json-schemas-and-settings)
as an example).

Currently, the JSON schema for the `dclint` configuration file does
not allow `$schema`, so adding it causes a configuration validation
error and prevents the tool from starting.

This adds `$schema` to the configuration JSON schema and documents how
to use it.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
