### PR TITLE
Observe `quiet` field in configuration file

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -109,7 +109,7 @@ async function main() {
 
   let lintResults = await linter.lintFiles(cliArguments.files, cliArguments.recursive);
 
-  if (cliArguments.quiet) {
+  if (config.quiet) {
     lintResults = lintResults
       .map((result) => ({
         ...result,


### PR DESCRIPTION
## Description

Previously, the `quiet` field in the configuration file would be
ignored by the CLI, only the `--quiet` command-line flag would
work. Now, both work.

Note that `DCLinter` does not observe the `quiet` configuration field.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
  I didn't see any existing tests for the CLI. I started building tests for `DCLinter`, but then realized it a) is a different code path than the CLI and b) doesn't support `quiet` anyway.
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
