### PR TITLE
feat: add data field to LintMessage

### DIFF
--- a/src/linter/linter.ts
+++ b/src/linter/linter.ts
@@ -113,6 +113,7 @@ class DCLinter {
           column: startPos?.col || 1,
           type: 'error',
           fixable: false,
+          data: {},
         });
       } else if (error instanceof ComposeValidationError) {
         messages.push({
@@ -124,6 +125,7 @@ class DCLinter {
           line: 1,
           column: 1,
           fixable: false,
+          data: {},
         });
       } else {
         messages.push({
@@ -135,6 +137,7 @@ class DCLinter {
           column: 1,
           type: 'error',
           fixable: false,
+          data: {},
         });
       }
 

--- a/src/linter/linter.types.ts
+++ b/src/linter/linter.types.ts
@@ -16,6 +16,7 @@ interface LintMessage {
   endColumn?: number; // The column number where the issue ends (optional)
   meta?: RuleMeta; // Metadata about the rule, including description and URL
   fixable: boolean; // Is it possible to fix this issue
+  data: object;
 }
 
 interface LintResult {

--- a/src/rules/no-build-and-image-rule.ts
+++ b/src/rules/no-build-and-image-rule.ts
@@ -79,6 +79,9 @@ export default class NoBuildAndImageRule implements LintRule {
           column: 1,
           meta: this.meta,
           fixable: this.fixable,
+          data: {
+            serviceName,
+          },
         });
       }
     });

--- a/src/rules/no-duplicate-container-names-rule.ts
+++ b/src/rules/no-duplicate-container-names-rule.ts
@@ -58,6 +58,7 @@ export default class NoDuplicateContainerNamesRule implements LintRule {
         const containerName = String(service.get('container_name'));
 
         if (containerNames.has(containerName)) {
+          const anotherService = String(containerNames.get(containerName));
           const line = findLineNumberForService(parsedDocument, context.sourceCode, serviceName, 'container_name');
           errors.push({
             rule: this.name,
@@ -67,12 +68,17 @@ export default class NoDuplicateContainerNamesRule implements LintRule {
             message: this.getMessage({
               serviceName,
               containerName,
-              anotherService: String(containerNames.get(containerName)),
+              anotherService,
             }),
             line,
             column: 1,
             meta: this.meta,
             fixable: this.fixable,
+            data: {
+              serviceName,
+              containerName,
+              anotherService,
+            },
           });
         } else {
           containerNames.set(containerName, serviceName);

--- a/src/rules/no-duplicate-exported-ports-rule.ts
+++ b/src/rules/no-duplicate-exported-ports-rule.ts
@@ -81,6 +81,11 @@ export default class NoDuplicateExportedPortsRule implements LintRule {
               column: 1,
               meta: this.meta,
               fixable: this.fixable,
+              data: {
+                serviceName,
+                publishedPort,
+                exportedPortsMap,
+              },
             });
             return true;
           }

--- a/src/rules/no-quotes-in-volumes-rule.ts
+++ b/src/rules/no-quotes-in-volumes-rule.ts
@@ -69,6 +69,9 @@ export default class NoQuotesInVolumesRule implements LintRule {
           column: 1,
           meta: this.meta,
           fixable: this.fixable,
+          data: {
+            volume,
+          },
         });
       }
     });

--- a/src/rules/no-unbound-port-interfaces-rule.ts
+++ b/src/rules/no-unbound-port-interfaces-rule.ts
@@ -68,6 +68,10 @@ export default class NoUnboundPortInterfacesRule implements LintRule {
             column: 1,
             meta: this.meta,
             fixable: this.fixable,
+            data: {
+              serviceName,
+              portItem,
+            },
           });
         }
       });

--- a/src/rules/no-version-field-rule.ts
+++ b/src/rules/no-version-field-rule.ts
@@ -44,6 +44,7 @@ export default class NoVersionFieldRule implements LintRule {
         column: 1,
         meta: this.meta,
         fixable: this.fixable,
+        data: {},
       });
     }
 

--- a/src/rules/require-project-name-field-rule.ts
+++ b/src/rules/require-project-name-field-rule.ts
@@ -43,6 +43,7 @@ export default class RequireProjectNameFieldRule implements LintRule {
         column: 1,
         meta: this.meta,
         fixable: this.fixable,
+        data: {},
       });
     }
 

--- a/src/rules/require-quotes-in-ports-rule.ts
+++ b/src/rules/require-quotes-in-ports-rule.ts
@@ -104,6 +104,11 @@ export default class RequireQuotesInPortsRule implements LintRule {
             column: 1,
             meta: this.meta,
             fixable: this.fixable,
+            data: {
+              service,
+              port,
+              section,
+            },
           });
         }
       });

--- a/src/rules/service-container-name-regex-rule.ts
+++ b/src/rules/service-container-name-regex-rule.ts
@@ -63,6 +63,10 @@ export default class ServiceContainerNameRegexRule implements LintRule {
           column: 1,
           meta: this.meta,
           fixable: this.fixable,
+          data: {
+            serviceName,
+            containerName,
+          },
         });
       }
     });

--- a/src/rules/service-dependencies-alphabetical-order-rule.ts
+++ b/src/rules/service-dependencies-alphabetical-order-rule.ts
@@ -78,6 +78,9 @@ export default class ServiceDependenciesAlphabeticalOrderRule implements LintRul
           column: 1,
           meta: this.meta,
           fixable: this.fixable,
+          data: {
+            serviceName,
+          },
         });
       }
     });

--- a/src/rules/service-image-require-explicit-tag-rule.ts
+++ b/src/rules/service-image-require-explicit-tag-rule.ts
@@ -85,6 +85,10 @@ export default class ServiceImageRequireExplicitTagRule implements LintRule {
           column: 1,
           meta: this.meta,
           fixable: this.fixable,
+          data: {
+            image,
+            serviceName,
+          },
         });
       }
     });

--- a/src/rules/service-keys-order-rule.ts
+++ b/src/rules/service-keys-order-rule.ts
@@ -141,6 +141,11 @@ export default class ServiceKeysOrderRule implements LintRule {
             column: 1,
             meta: this.meta,
             fixable: this.fixable,
+            data: {
+              serviceName,
+              key,
+              correctOrder,
+            },
           });
         }
 

--- a/src/rules/service-ports-alphabetical-order-rule.ts
+++ b/src/rules/service-ports-alphabetical-order-rule.ts
@@ -65,6 +65,9 @@ export default class ServicePortsAlphabeticalOrderRule implements LintRule {
           column: 1,
           meta: this.meta,
           fixable: this.fixable,
+          data: {
+            serviceName,
+          },
         });
       }
     });

--- a/src/rules/services-alphabetical-order-rule.ts
+++ b/src/rules/services-alphabetical-order-rule.ts
@@ -74,6 +74,10 @@ export default class ServicesAlphabeticalOrderRule implements LintRule {
           column: 1,
           meta: this.meta,
           fixable: this.fixable,
+          data: {
+            serviceName,
+            misplacedBefore,
+          },
         });
       }
 

--- a/src/rules/top-level-properties-order-rule.ts
+++ b/src/rules/top-level-properties-order-rule.ts
@@ -99,6 +99,10 @@ export default class TopLevelPropertiesOrderRule implements LintRule {
           column: 1,
           meta: this.meta,
           fixable: this.fixable,
+          data: {
+            key,
+            correctOrder,
+          },
         });
       } else {
         lastSeenIndex = expectedIndex;


### PR DESCRIPTION
## Description

Add a `data` field to the message so external tools can be used to do something with the result of `dclint`.

For example, I want to automatically fetch all available tags for an image so I don't have to look them up on Docker Hub.

```bash
# run local dclint from this branch on my docker-compose.yml
node ~/src/docker-compose-linter/bin/dclint.cjs -f json docker-compose.yml > /tmp/tt-rss.json

# Select service-image-require-explicit-tag rule and get tags for the images
jq -r '.[] | .messages[] | select(.rule == "service-image-require-explicit-tag") | .data.image' /tmp/tt-rss.json \
  | tr '\n' '\0' | xargs -I{} -0 bash -c 'set -x; image="{}"; nix run nixpkgs#skopeo -- list-tags "docker://${image%:*}"'
```

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional Context / Screenshots (if appropriate)

Provide any additional context or screenshots that might help the reviewer understand the pull request better.
