### PR TITLE
Add profiles to service-keys-order rule

### DIFF
--- a/docs/rules/service-keys-order-rule.md
+++ b/docs/rules/service-keys-order-rule.md
@@ -101,7 +101,7 @@ behavior, which is vital for ensuring that the service starts, runs, and maintai
 
 ### Operational Metadata
 
-**Properties:** `logging`, `labels`
+**Properties:** `logging`, `labels`, `profiles`
 
 Metadata and logging configurations are important for monitoring, categorizing, and managing the service, but they are
 secondary to its core operation. By grouping them near the end, the focus remains on the services functionality, while

--- a/src/rules/service-keys-order-rule.ts
+++ b/src/rules/service-keys-order-rule.ts
@@ -73,7 +73,7 @@ class ServiceKeysOrderRule implements Rule {
         [ServiceKeyGroup.ENVIRONMENT]: ['environment', 'env_file'],
         [ServiceKeyGroup.NETWORK]: ['ports', 'networks', 'network_mode', 'extra_hosts'],
         [ServiceKeyGroup.RUNTIME]: ['command', 'entrypoint', 'working_dir', 'restart', 'healthcheck'],
-        [ServiceKeyGroup.METADATA]: ['logging', 'labels'],
+        [ServiceKeyGroup.METADATA]: ['logging', 'labels', 'profiles'],
         [ServiceKeyGroup.SECURITY]: ['user', 'isolation'],
         [ServiceKeyGroup.OTHER]: [],
       },

--- a/tests/rules/service-keys-order-rule.spec.ts
+++ b/tests/rules/service-keys-order-rule.spec.ts
@@ -48,7 +48,7 @@ test('ServiceKeysOrderRule: should return a warning when service keys are in the
   };
 
   const correctOrder = [
-    'image, build, container_name, depends_on, volumes, volumes_from, configs, secrets, environment, env_file, ports, networks, network_mode, extra_hosts, command, entrypoint, working_dir, restart, healthcheck, logging, labels, user, isolation, annotations, cpu_rt_period, cpu_rt_runtime',
+    'image, build, container_name, depends_on, volumes, volumes_from, configs, secrets, environment, env_file, ports, networks, network_mode, extra_hosts, command, entrypoint, working_dir, restart, healthcheck, logging, labels, profiles, user, isolation, annotations, cpu_rt_period, cpu_rt_runtime',
   ];
   const expectedMessages = [
     rule.getMessage({ serviceName: 'web', key: 'ports', correctOrder }),


### PR DESCRIPTION
---
title: "Add profiles to service-keys-order rule"
---

## Description

Currently `profiles` is missing from the rule and it will therefore complain if it is not listed last. I've added it together with `logging` and `labels` where I believe it makes most sense.

## Related Issues

Link any related issues or feature requests. For example:

- 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Context / Screenshots (if appropriate)

- 
